### PR TITLE
Feature  gamehudvisual

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -47,11 +47,12 @@ body{
 	font-size: 14px;
 }
 .game-container__upgrades {
-	height: 510px;
+	height: 375px;
 	overflow-y: scroll; /* has to be scroll, not auto */
   	-webkit-overflow-scrolling: touch;
   	top: 112px;
   	width: 100%;
+  	padding-left: 7px;
 }
 .pull-right{
 	font-size: 33px;
@@ -67,6 +68,8 @@ body{
 .button-wrapper{
 	text-align: center;
 	width: 100%;
+	padding-left: 6px;
+	padding-right: 2px;
 }
 button.btn.btn-primary.btn-raised.js-clicker{
 	width: 97%;
@@ -75,13 +78,21 @@ button.btn.btn-primary.btn-raised.js-clicker{
 .upgrade-item__image{
 	max-width: 60px;
 }
-.shadow{
+.main-shadow{
 	box-shadow: 0px 6px 47px #290754;
 	text-shadow: 0px 2px #24054A;
 }
-.progress{
+.main-progress{
+	text-align: center;
+	margin: 5px;
 	height: 18px !important;
 	background: #393851 !important;
+}
+.progress-value {
+	position: absolute;
+	right: 0;
+	left: 0;
+	font-size: 13px;
 }
 .game-hud{
 	padding:6px 0;
@@ -94,7 +105,7 @@ button.btn.btn-primary.btn-raised.js-clicker{
 	width: 10px;
 }
 ::-webkit-scrollbar-thumb{ 
-	background: white; 
+	background: rgb(87, 51, 132); 
 	border-radius: 8px;
 	 
 	-webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75); 

--- a/css/game.css
+++ b/css/game.css
@@ -1,5 +1,6 @@
 body{
 	background-color: #3c3b52 !important;
+	overflow: hidden;
 }
 .container{
 	padding:0;
@@ -17,7 +18,7 @@ body{
 .game-hud__score{
 	color: white;
 	font-family: 'Roboto', sans-serif;
-	font-size: 30px;
+	font-size: 40px;
 }
 .money-container{
 	color: white;
@@ -27,9 +28,13 @@ body{
 .money-container>span{
 	display: inline-block;
 }
-.ppc-container{
+.game-hud__stat{
 	font-family: 'Roboto', sans-serif;
-	font-size: 13px;	
+	font-size: 17px;	
+}
+.game-hud__stat:hover {
+	font-size: 20px;
+	color: rgb(116, 16, 195);
 }
 .game-hud{
 	color: white;
@@ -39,23 +44,26 @@ body{
 	padding: 10px;
 	background: rgba(0,0,0,.3); 
 	margin:6px auto;
+	font-size: 14px;
 }
 .game-container__upgrades {
-	position:absolute;
-	left:0;
-	bottom:0;
-	width:100%;
-	height:65%;
+	height: 510px;
 	overflow-y: scroll; /* has to be scroll, not auto */
   	-webkit-overflow-scrolling: touch;
   	top: 112px;
+  	width: 100%;
 }
 .pull-right{
-	font-size: 25px;
+	font-size: 33px;
 }
 .media-body{
 	color: white;
+	font-size: 18px;
 }
+.media-heading{
+	font-size: 22px;
+}
+
 .button-wrapper{
 	text-align: center;
 	width: 100%;
@@ -67,12 +75,27 @@ button.btn.btn-primary.btn-raised.js-clicker{
 .upgrade-item__image{
 	max-width: 60px;
 }
+.shadow{
+	box-shadow: 0px 6px 47px #290754;
+	text-shadow: 0px 2px #24054A;
+}
+.progress{
+	height: 18px !important;
+	background: #393851 !important;
+}
+.game-hud{
+	padding:6px 0;
+}
+.progress-bar{
+	font-size: 18px;
+	text-align: center;
+}
 ::-webkit-scrollbar{
-	width: 5px;
+	width: 10px;
 }
 ::-webkit-scrollbar-thumb{ 
 	background: white; 
-	border-radius: 3px;
+	border-radius: 8px;
 	 
 	-webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75); 
 } 

--- a/game.html
+++ b/game.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <div class="container">
-            <div class="game-hud text-center shadow">
+            <div class="game-hud text-center main-shadow">
                 <div class="game-hud__score js-score">
                     0
                 </div>
@@ -44,10 +44,13 @@
                         <span class="js-experience">0</span>
                     </div>
                 </div>
-                <div class="progress">
-                  <div class="js-progress progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%">
-                    Level <span class=" text-center game-hud__level js-level">0</span>
-                  </div>
+                <div class="main-progress">  
+                    <div class="progress-value">
+                        Level
+                        <span class=" text-center game-hud__level js-level">0</span>
+                    </div>
+                    <div class="js-progress progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%">
+                    </div>
                 </div>
             </div>
             <div class="container-upgrade">
@@ -64,8 +67,10 @@
 
         <!-- Include all compiled plugins (below), or include individual files as needed -->
         <script src="js/bootstrap.min.js"></script>
-        <script src="js/index.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.2.2/js/material.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-material-design/0.2.2/js/ripples.min.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
+        <script src="js/index.js"></script>
         <script src="js/upgrades.js"></script>
         <script src="js/game.js"></script>
 

--- a/game.html
+++ b/game.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <div class="container">
-            <div class="game-hud text-center">
+            <div class="game-hud text-center shadow">
                 <div class="game-hud__score js-score">
                     0
                 </div>
@@ -44,18 +44,15 @@
                         <span class="js-experience">0</span>
                     </div>
                 </div>
-                <div class="game-hud__progress progress">
-                    <div class="progress-bar progress-bar-striped active js-progress text-center" style="width: 0%">               
-                        Level:  <span class="game-hud__level js-level">0</span>                     
-                    </div>
+                <div class="progress">
+                  <div class="js-progress progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%">
+                    Level <span class=" text-center game-hud__level js-level">0</span>
+                  </div>
                 </div>
             </div>
             <div class="container-upgrade">
                 <div class="game-container__upgrades js-updates-output">
                 </div>
-            </div>
-            <div class="clicker-button">
-                <img src="img/penguin.png" alt="Punch me" />
             </div>
             <div class="button-wrapper">
                 <button class="btn btn-primary btn-raised js-clicker">Punch It!</button>

--- a/js/game.js
+++ b/js/game.js
@@ -37,7 +37,6 @@ $(document).ready(function(){
 
 });
 
-
 function saveData(){
 	localStorage.setItem('clickerSettings', JSON.stringify(settings));
 }
@@ -53,7 +52,7 @@ function loadData(){
 
 	settings = JSON.parse(localStorage.getItem('clickerSettings')) || defaultSettings;
 
-	settings = $.extend(settings, defaultSettings);
+	settings = $.extend(defaultSettings, settings);
 }
 
 function setEverything(){
@@ -65,11 +64,9 @@ function setEverything(){
 	$(".js-progress").width(getExperiencePercentage());
 }
 
-
 Handlebars.registerHelper('addCommas', function(number) {
   return numberWithCommas(number);
 });
-
 
 function setupUpgrades(){
 	var source   = $("#upgrade-template").html();
@@ -98,7 +95,7 @@ function figureOutLevel() {
 
 function getExperiencePercentage() {
 
-	var percentage = ((settings.experience - experienceNeeded(settings.level)) / experienceNeeded(settings.level + 1)) * 100;
+	var percentage = ( (settings.experience - experienceNeeded(settings.level)) / (experienceNeeded(settings.level + 1) - experienceNeeded(settings.level))) * 100;
 
 	return percentage + "%"
 }

--- a/js/upgrades.js
+++ b/js/upgrades.js
@@ -77,7 +77,7 @@ var data = {
 			pps: 0,
 			ppc: 10,
 			price:50000,
-			image:"img/diamond-pickaxe.png",
+			image:"img/404.png",
 			multiplier:1.5
 		},
 		{
@@ -93,7 +93,7 @@ var data = {
 			ppc: 0,
 			pps: 50000,
 			price:100000000,
-			image:"img/diamond-pickaxe.png",
+			image:"img/404.png",
 			multiplier:1.5
 		},
 		{


### PR DESCRIPTION
I have made the following changes:

Added current level inside of progress bar without being pushed as the bar increases. 
Added a slight drop shadow to the bottom of the Game HUD to make the upgrades container look like the upgrades have effect.

The game HUD has a equal margin on the top and bottom and does have hover effects overall the display of the hud looks better than previously. The progress bar also completes to when you would level up as brought up in issue #7. I have also changed the styling of the progress bar from the plain thin bar to a more thicker bar which you can see how far you have till you level up. 

Indentation seems fine and I have checked on game.js to make sure that their is only one line space between each different bit of coding. 